### PR TITLE
Add two error types to statemachine

### DIFF
--- a/statemachine.go
+++ b/statemachine.go
@@ -4,6 +4,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	NoConditionPassedToRunTransaction = errors.New("no condition found to run transition")
+	NoMatchForTransitionType          = errors.New("no match for transition type")
+)
+
 type StateMachine interface {
 	// AddTransition to state machine
 	AddTransition(rule TransitionRule)
@@ -26,7 +31,7 @@ type stateMachine struct {
 func (sm *stateMachine) Run(transitionType TransitionType, stateSwitch StateSwitch, args TransitionArgs) error {
 	transByType, ok := sm.transitionRules[transitionType]
 	if !ok {
-		return errors.Errorf("no match for transition type %s", transitionType)
+		return NoMatchForTransitionType
 	}
 
 	for _, tr := range transByType {
@@ -40,7 +45,6 @@ func (sm *stateMachine) Run(transitionType TransitionType, stateSwitch StateSwit
 					return err
 				}
 			}
-			//return sm.StateSwitchObj.SetState(tr.DestinationState)
 			if err := stateSwitch.SetState(tr.DestinationState); err != nil {
 				return err
 			}
@@ -50,8 +54,7 @@ func (sm *stateMachine) Run(transitionType TransitionType, stateSwitch StateSwit
 			return nil
 		}
 	}
-	return errors.Errorf("no condition passed to run transition %s from state %s",
-		transitionType, stateSwitch.State())
+	return NoConditionPassedToRunTransaction
 }
 
 // AddTransition to state machine

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -101,11 +101,13 @@ var _ = Describe("Run", func() {
 		gomega.Expect(sw.state).Should(gomega.Equal(stateB))
 	})
 	It("transition type not found", func() {
-		gomega.Expect(sm.Run("invalid transition type", sw, nil)).Should(gomega.HaveOccurred())
+		gomega.Expect(errors.Is(sm.Run("invalid transition type", sw, nil), NoMatchForTransitionType)).
+			Should(gomega.BeTrue())
 		gomega.Expect(sw.state).Should(gomega.Equal(stateA))
 	})
 	It("transition not permitted", func() {
-		gomega.Expect(sm.Run(ttNotPermittedAToC, sw, nil)).Should(gomega.HaveOccurred())
+		gomega.Expect(errors.Is(sm.Run(ttNotPermittedAToC, sw, nil), NoConditionPassedToRunTransaction)).
+			Should(gomega.BeTrue())
 		gomega.Expect(sw.state).Should(gomega.Equal(stateA))
 	})
 	It("condition error", func() {


### PR DESCRIPTION
NoConditionPassedToRunTransaction - when no matching state or no condition passed
NoMatchForTransitionType - transition type is not supported