### PR TITLE
Bump golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PWD = $(shell pwd)
 all: lint test
 
 lint:
-	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.26.0 golangci-lint run -v
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.50.1 golangci-lint run -v
 
 test:
 	go test -v ./... -cover -ginkgo.v


### PR DESCRIPTION
The older version uses old deprecated linters that work poorly, giving
false positives.