### PR TITLE
Clarify the concepts of `TransitionType`s vs `TransitionRule`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple and clear way to create and represent state machine.
 sm := stateswitch.NewStateMachine()
 
 // Define the state machine rules (and optionally document each rule)
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
     TransitionType:   TransitionTypeSetHwInfo,
     SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
     DestinationState: StateKnown,
@@ -22,7 +22,7 @@ sm.AddTransition(stateswitch.TransitionRule{
         Description: "Once we receive hardware information from a server, we can consider it known if the hardware information is sufficient",
     },
 })
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
     TransitionType:   TransitionTypeSetHwInfo,
     SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
     DestinationState: StateInsufficient,
@@ -34,7 +34,7 @@ sm.AddTransition(stateswitch.TransitionRule{
         Description: "Once we receive hardware infomration from a server, we consider the server to be insufficient if the hardware is insufficient",
     },
 })
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
     TransitionType:   TransitionTypeRegister,
     SourceStates:     stateswitch.States{""},
     DestinationState: StateDiscovering,
@@ -46,7 +46,7 @@ sm.AddTransition(stateswitch.TransitionRule{
         Description: "A new server which registers enters our initial discovering state",
     },
 })
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
     TransitionType:   TransitionTypeRegister,
     SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
     DestinationState: StateDiscovering,
@@ -106,7 +106,7 @@ sm := stateswitch.NewStateMachine()
 Add transitions with the expected behavior 
 
 ```go
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
 	TransitionType:   TransitionTypeSetHwInfo,
 	SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
 	DestinationState: StateInsufficient,
@@ -129,7 +129,7 @@ Since `Condtion` represent boolean entity, stateswitch provides means to create 
 boolean operations: `Not`,`And`, `Or`.  For example, rule with complex condition:
 
 ```go
-sm.AddTransition(stateswitch.TransitionRule{
+sm.AddTransitionRule(stateswitch.TransitionRule{
     TransitionType:   TransitionTypeSetHwInfo,
     SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
     DestinationState: StatePending,

--- a/examples/host/host/host.go
+++ b/examples/host/host/host.go
@@ -38,7 +38,7 @@ const (
 func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm := stateswitch.NewStateMachine()
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeSetHwInfo,
 		SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
 		DestinationState: StateKnown,
@@ -47,7 +47,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostSetHwInfo,
 	})
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeSetHwInfo,
 		SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
 		DestinationState: StateInsufficient,
@@ -56,7 +56,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostSetHwInfo,
 	})
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeRegister,
 		SourceStates:     stateswitch.States{""},
 		DestinationState: StateDiscovering,
@@ -65,7 +65,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.RegisterNew,
 	})
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeRegister,
 		SourceStates:     stateswitch.States{StateDiscovering, StateKnown, StateInsufficient},
 		DestinationState: StateDiscovering,

--- a/examples/student/main.go
+++ b/examples/student/main.go
@@ -80,7 +80,7 @@ func (stm *studentMachine) SetGrade(s *Student, grade int) error {
 func NewStudentMachine() *studentMachine {
 	sm := stateswitch.NewStateMachine()
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeSetGrade,
 		SourceStates:     []stateswitch.State{StatePending, StateFailed, StatePassed},
 		DestinationState: StatePassed,
@@ -88,7 +88,7 @@ func NewStudentMachine() *studentMachine {
 		Transition:       SetGradeTransition,
 	})
 
-	sm.AddTransition(stateswitch.TransitionRule{
+	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeSetGrade,
 		SourceStates:     []stateswitch.State{StatePending, StateFailed, StatePassed},
 		DestinationState: StateFailed,

--- a/statemachine.go
+++ b/statemachine.go
@@ -10,7 +10,9 @@ var (
 )
 
 type StateMachine interface {
-	// AddTransition to state machine
+	// AddTransitionRule adds a new transition rule to the state machine
+	AddTransitionRule(rule TransitionRule)
+	// AddTransition is a deprecated method, use AddTransitionRule instead
 	AddTransition(rule TransitionRule)
 	// Run transition by type
 	Run(transitionType TransitionType, stateSwitch StateSwitch, args TransitionArgs) error
@@ -64,7 +66,10 @@ func (sm *stateMachine) Run(transitionType TransitionType, stateSwitch StateSwit
 	return NoConditionPassedToRunTransaction
 }
 
-// AddTransition to state machine
 func (sm *stateMachine) AddTransition(rule TransitionRule) {
+	sm.AddTransitionRule(rule)
+}
+
+func (sm *stateMachine) AddTransitionRule(rule TransitionRule) {
 	sm.transitionRules[rule.TransitionType] = append(sm.transitionRules[rule.TransitionType], rule)
 }

--- a/statemachine_doc_test.go
+++ b/statemachine_doc_test.go
@@ -13,7 +13,7 @@ var _ = Describe("State machine documentation", func() {
 		srcStates := States{"StateA", "StateB"}
 		dstState := State("StateC")
 
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   transitionType,
 			SourceStates:     []State{""},
 			DestinationState: dstState,
@@ -25,7 +25,7 @@ var _ = Describe("State machine documentation", func() {
 			},
 		})
 
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   transitionType,
 			SourceStates:     srcStates,
 			DestinationState: dstState,

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _ = Describe("AddTransition", func() {
-	It("AddTransition", func() {
+var _ = Describe("AddTransitionRule", func() {
+	It("AddTransitionRule", func() {
 		sm := NewStateMachine()
 
 		transitionType := TransitionType("TransitionType")
@@ -20,7 +20,7 @@ var _ = Describe("AddTransition", func() {
 			return true, nil
 		}
 
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   transitionType,
 			SourceStates:     srcStates,
 			DestinationState: dstState,
@@ -48,7 +48,7 @@ var _ = Describe("Run", func() {
 		swErr = &swError{state: stateA}
 
 		sm = NewStateMachine()
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttAToB,
 			SourceStates:     []State{stateA},
 			DestinationState: stateB,
@@ -56,35 +56,35 @@ var _ = Describe("Run", func() {
 			Transition:       nil,
 			PostTransition:   func(stateSwitch StateSwitch, args TransitionArgs) error { return nil },
 		})
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttNotPermittedAToC,
 			SourceStates:     []State{stateA},
 			DestinationState: stateC,
 			Condition:        func(stateSwitch StateSwitch, args TransitionArgs) (bool, error) { return false, nil },
 			Transition:       nil,
 		})
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttConditionError,
 			SourceStates:     []State{stateA, stateB},
 			DestinationState: stateC,
 			Condition:        func(stateSwitch StateSwitch, args TransitionArgs) (bool, error) { return false, errors.Errorf("error") },
 			Transition:       nil,
 		})
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttBToC,
 			SourceStates:     []State{stateB},
 			DestinationState: stateC,
 			Condition:        func(stateSwitch StateSwitch, args TransitionArgs) (bool, error) { return true, nil },
 			Transition:       func(stateSwitch StateSwitch, args TransitionArgs) error { return nil },
 		})
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttBToA,
 			SourceStates:     []State{stateB},
 			DestinationState: stateA,
 			Condition:        func(stateSwitch StateSwitch, args TransitionArgs) (bool, error) { return true, nil },
 			Transition:       func(stateSwitch StateSwitch, args TransitionArgs) error { return errors.Errorf("error") },
 		})
-		sm.AddTransition(TransitionRule{
+		sm.AddTransitionRule(TransitionRule{
 			TransitionType:   ttAToBPostTransitionErr,
 			SourceStates:     []State{stateA},
 			DestinationState: stateB,

--- a/transition.go
+++ b/transition.go
@@ -1,7 +1,11 @@
 package stateswitch
 
+// TransitionType reprents an event that can cause a state transition
 type TransitionType string
 
+// TransitionRule is a rule that defines the required source states and
+// conditions needed to move to a particular destination state when a
+// particular transition type happens
 type TransitionRule struct {
 	TransitionType   TransitionType
 	SourceStates     States


### PR DESCRIPTION
This is achieved by adding a few code docs and deprecating the
misleadingly named `AddTransition` method, replacing it with a new
method called `AddTransitionRule`