### PR TITLE
Improve transition error

### DIFF
--- a/statemachine.go
+++ b/statemachine.go
@@ -63,7 +63,8 @@ func (sm *stateMachine) Run(transitionType TransitionType, stateSwitch StateSwit
 			return nil
 		}
 	}
-	return NoConditionPassedToRunTransaction
+	return errors.Wrapf(NoConditionPassedToRunTransaction, "transition type [%s] source state [%s]",
+		transitionType, stateSwitch.State())
 }
 
 func (sm *stateMachine) AddTransition(rule TransitionRule) {


### PR DESCRIPTION
Add information to  error
Adding transition type and source setate

example:
transition type [notPermittedAToC] source state [a]: no condition found to run transition

Error type remain the same